### PR TITLE
refactor(action): rename terraform-dir input to tf-config-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ A GitHub Composite Action to lint Terraform code using [TFLint](https://github.c
 
 | Name              | Description                                                                 | Required | Default     |
 |-------------------|-----------------------------------------------------------------------------|----------|-------------|
-| `terraform-dir`   | Relative path to the directory containing Terraform configuration files. Can be combined with cloud-provider for multi-cloud setups | No       | `tf`        |
-| `cloud-provider`  | Cloud provider for multi-cloud setups (`aws`, `gcp`, `azure`). When specified, modifies terraform-dir to `infra/<cloud-provider>/tf` | No       | `""` (disabled) |
+| `tf-config-path`  | Relative path to the directory containing Terraform configuration files. Can be combined with cloud-provider for multi-cloud setups | No       | `tf`        |
+| `cloud-provider`  | Cloud provider for multi-cloud setups (`aws`, `gcp`, `azure`). When specified, modifies tf-config-path to `infra/<cloud-provider>/tf` | No       | `""` (disabled) |
 | `release-tag`     | Git release tag to check out. If omitted, the current branch or tag is used | No       | `""`        |
 | `tflint-ver`      | TFLint version to install (e.g., `v0.52.0`). Pass organization variable `TF_LINT_VER` from calling workflow | No       | `v0.52.0` |
 | `use-cache`       | Enable plugin caching (`true` or `false`)                                   | No       | `true`      |
@@ -76,7 +76,7 @@ jobs:
       - name: Run TFLint
         uses: subhamay-bhattacharyya-gha/tf-lint-action@main
         with:
-          terraform-dir: "tf"
+          tf-config-path: "tf"
           release-tag: ""
           tflint-ver: "v0.52.0"
           use-cache: "true"
@@ -97,7 +97,7 @@ To use an organization variable for the default TFLint version, pass it from you
       - name: Run TFLint with Organization Variable
         uses: subhamay-bhattacharyya-gha/tf-lint-action@main
         with:
-          terraform-dir: "infrastructure"
+          tf-config-path: "infrastructure"
           tflint-ver: ${{ vars.TF_LINT_VER || 'v0.52.0' }}
           use-cache: "true"
           tflint-format: "json"

--- a/action.yaml
+++ b/action.yaml
@@ -2,7 +2,7 @@ name: "Terraform Lint with TFLint"
 description: "A composite GitHub Action that installs and runs TFLint to detect issues in Terraform code."
 
 inputs:
-  terraform-dir:
+  tf-config-path:
     description: "Relative path to the directory containing Terraform configuration files (e.g., 'tf', 'infrastructure'). Can be combined with cloud-provider for multi-cloud setups."
     required: false
     type: string
@@ -45,7 +45,7 @@ runs:
       shell: bash
       run: |
         echo "=== GitHub Action Inputs ==="
-        echo "terraform-dir: ${{ inputs.terraform-dir }}"
+        echo "tf-config-path: ${{ inputs.tf-config-path }}"
         echo "cloud-provider: ${{ inputs.cloud-provider }}"
         echo "release-tag: ${{ inputs.release-tag }}"
         echo "tflint-ver: ${{ inputs.tflint-ver }}"
@@ -69,8 +69,8 @@ runs:
               ;;
           esac
         else
-          echo "dir=${{ inputs.terraform-dir }}" >> $GITHUB_OUTPUT
-          echo "Using specified terraform-dir: ${{ inputs.terraform-dir }}"
+          echo "dir=${{ inputs.tf-config-path }}" >> $GITHUB_OUTPUT
+          echo "Using specified tf-config-path: ${{ inputs.tf-config-path }}"
         fi
 
     - name: Set TFLint Version


### PR DESCRIPTION
- Rename `terraform-dir` input parameter to `tf-config-path` for improved clarity
- Update all references in README.md documentation and usage examples
- Update action.yaml input definition and debug output statements
- Update cloud-provider description to reference new `tf-config-path` parameter
- Improve semantic naming to better reflect the input's purpose as a configuration path